### PR TITLE
BMSCS 25.06.0: remove deprecated argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BMSCS
 Title: Interface for Bayesian Model Selection under Constraints
-Version: 25.03.1
+Version: 25.06.0
 Authors@R: c(
     person("Marcus", "Groß", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BMSCS 25.06.0
+
+## Bug Fixes
+- fixed broken model export due to passing a deprecated argument that was removed in the meanwhile (#44)
+
 # BMSCS 25.03.1
 
 ## Updates

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -183,7 +183,6 @@ modelEstimation <- function(input, output, session, data) {
                       model = modelsForDownload,
                       rPackageName = config()[["rPackageName"]],
                       fileExtension = config()[["fileExtension"]],
-                      helpHTML = getHelp(id = ""),
                       modelNotes = modelNotes,
                       triggerUpdate = reactive(TRUE))
   

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -8,12 +8,4 @@ function(input, output, session) {
   options("scipen"=100, "digits"=4)
   data <- shiny::callModule(dataInput, "data")
   shiny::callModule(modelEstimation, "model", data)
-  
-  observeEvent(input$getHelp, {
-    showModal(modalDialog(
-      title = "Help",
-      easyClose = TRUE,
-      getHelp(input$tab)
-    ))
-  })
 }


### PR DESCRIPTION
# BMSCS 25.06.0

## Bug Fixes
- fixed broken model export due to passing a deprecated argument that was removed in the meanwhile (#44)