### PR TITLE
BMSCS 25.07.1: Bug/44 crash when inverse exp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BMSCS
 Title: Interface for Bayesian Model Selection under Constraints
-Version: 25.07.0
+Version: 25.07.1
 Authors@R: c(
     person("Marcus", "Groß", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# BMSCS 25.07.1
+
+## Bug Fixes
+- Fixed an issue where the app could crash if some models did not return valid results (#44).
+  The update now handles NaN values in model outputs gracefully. If modeling results are missing or 
+  invalid, they are excluded from the output summaries or replaced with a clear error message, 
+  preventing unexpected crashes.
+
 # BMSCS 25.07.0
 
 ## Bug Fixes

--- a/R/02-modelDW.R
+++ b/R/02-modelDW.R
@@ -33,7 +33,8 @@ modelDW <- function(input, output, session, model, data, modelAVG) {
                            dependent = model()$dependent,
                            inDat = data(), 
                            asDataFrame = TRUE) %>% 
-      bindAllResults(addEmptyRow = TRUE)
+      bindAllResults(addEmptyRow = TRUE) %>%
+      shinyTryCatch(errorTitle = "Extracting model results failed")
     
     allDW(thisDW)
   })
@@ -107,10 +108,16 @@ extractAllDW <- function(allModels, maxLag, dependent, inDat, asDataFrame = TRUE
 }
 
 printDWTest <- function(inDat, dependent, mPar, tVar, maxLag) {
-  print(
-    durbinWatsonTest(lm(I(inDat[, dependent] -
-                            BMSC::predict(mPar, newdata = inDat)) ~
-                          tVar), 
-                     max.lag = maxLag)
-  )
+  predictions <- BMSC::predict(mPar, newdata = inDat)
+  
+  if (all(is.nan(predictions))) {
+    print("Predictions are all NaN. Please check the model parameters and input data.")
+  } else {
+    print(
+      durbinWatsonTest(lm(I(inDat[, dependent] -
+                              BMSC::predict(mPar, newdata = inDat)) ~
+                            tVar), 
+                       max.lag = maxLag)
+    )
+  }
 }

--- a/R/02-modelDW.R
+++ b/R/02-modelDW.R
@@ -113,11 +113,10 @@ printDWTest <- function(inDat, dependent, mPar, tVar, maxLag) {
   if (all(is.nan(predictions))) {
     print("Predictions are all NaN. Please check the model parameters and input data.")
   } else {
-    print(
-      durbinWatsonTest(lm(I(inDat[, dependent] -
-                              BMSC::predict(mPar, newdata = inDat)) ~
-                            tVar), 
-                       max.lag = maxLag)
-    )
+    print(durbinWatsonTest(lm(I(
+      inDat[, dependent] -
+        predictions
+    ) ~
+      tVar), max.lag = maxLag))
   }
 }

--- a/R/02-modelDiagnostics.R
+++ b/R/02-modelDiagnostics.R
@@ -30,7 +30,8 @@ modelDiagnostics <- function(input, output, session, model, nChains) {
     
     thisDiagnostics <- extractAllDiagnostics(allModels = model()$models,
                                              nChains = nChains) %>% 
-      bindAllResults(addEmptyRow = TRUE)
+      bindAllResults(addEmptyRow = TRUE) %>%
+      shinyTryCatch(errorTitle = "Extracting model results failed")
     
     allDiagnostics(thisDiagnostics)
   })

--- a/R/02-modelEvaluation.R
+++ b/R/02-modelEvaluation.R
@@ -47,7 +47,8 @@ modelEvaluation <- function(input, output, session, model) {
                                    modelNames = names(model()$models),
                                    withColumnICName = TRUE)
     ) %>% 
-      bindAllResults(addEmptyRow = TRUE)
+      bindAllResults(addEmptyRow = TRUE) %>%
+      shinyTryCatch(errorTitle = "Extracting model results failed")
     
     allICData(thisICData)
   })

--- a/R/02-modelSummary.R
+++ b/R/02-modelSummary.R
@@ -29,7 +29,8 @@ modelSummary <- function(input, output, session, model, modelAVG) {
       allModels = model()$models,
       cLevel = input$quantileInt
     ) %>% 
-      bindAllResults(addEmptyRow = TRUE)
+      bindAllResults(addEmptyRow = TRUE) %>%
+      shinyTryCatch(errorTitle = "Extracting model results failed")
     
     allSummaries(thisSummaries)
   })

--- a/R/02-modelSummary.R
+++ b/R/02-modelSummary.R
@@ -25,10 +25,8 @@ modelSummary <- function(input, output, session, model, modelAVG) {
   observe({
     req(model())
     
-    thisSummaries <- extractAllSummaries(
-      allModels = model()$models,
-      cLevel = input$quantileInt
-    ) %>% 
+    thisSummaries <- extractAllSummaries(allModels = model()$models,
+                                         cLevel = input$quantileInt) %>%
       bindAllResults(addEmptyRow = TRUE) %>%
       shinyTryCatch(errorTitle = "Extracting model results failed")
     
@@ -80,7 +78,16 @@ extractAllSummaries <- function(allModels, cLevel, asDataFrame = TRUE) {
 }
 
 extractSummary <- function(model, cLevel = 0.95) {
-  capture.output({
-    print(model, cLevel = cLevel)
-  })
+  res <- try(print(model, cLevel = cLevel), silent = TRUE)
+  
+  if (inherits(res, "try-error")) {
+    capture.output({
+      print(res[[1]])
+    })
+  } else {
+    # if no error, capture output
+    capture.output({
+      print(model, cLevel = cLevel)
+    })
+  }
 }

--- a/R/02-modelVariablesImp.R
+++ b/R/02-modelVariablesImp.R
@@ -173,6 +173,10 @@ extract_coeff_from_model <- function(model, cLevel = 0.95) {
   
   # Compute summary statistics
   summary_list <- lapply(as.data.frame(all_rescaled), function(x) {
+    if (all(is.nan(x))) {
+      return(list(Estimate = NaN, Median = NaN, SD = NaN, Cred_Interval_Min = NaN, Cred_Interval_Max = NaN))
+    }
+    
     list(
       Estimate = mean(x),
       Median = median(x),

--- a/R/02-modelVariablesImp.R
+++ b/R/02-modelVariablesImp.R
@@ -32,7 +32,8 @@ modelVariablesImp <- function(input, output, session, model, modelAVG) {
     thisVarImp <- extractAllVariableImportance(models = model()$models,
                                                variableData = model()$variableData) %>%
       bindAllResults(addEmptyRow = TRUE) %>%
-      dplyr::select("Model", "Variable", "Importance", "Estimate", "Sign")
+      dplyr::select("Model", "Variable", "Importance", "Estimate", "Sign") %>%
+      shinyTryCatch(errorTitle = "Extracting model results failed")
     
     allVariableImportance(thisVarImp)
   })

--- a/R/03-modelEstimation.R
+++ b/R/03-modelEstimation.R
@@ -141,7 +141,8 @@ modelEstimation <- function(input, output, session, data) {
                   inverseExponent = input$inverseExp,
                   interactionDepth = input$interactionDepth,
                   intercept = input$intercept,
-                  categorical = xCategorical)
+                  categorical = xCategorical) %>%
+      shinyTryCatch(errorTitle = "Creating formula failed")
     
     ret <- gsub('[\n ]', '', strsplit(strsplit(as.character(FORMULA)[3], "~")[[1]], " \\+ ")[[1]])
     return(ret)
@@ -287,7 +288,7 @@ modelEstimation <- function(input, output, session, data) {
         shiny = TRUE,
         imputeMissings = input$imputeMissings
       ) %>%
-        shinyTryCatch()
+        shinyTryCatch(errorTitle = "Running model failed")
     },
     value = 0,
     message = "Calculation in progess",


### PR DESCRIPTION
# BMSCS 25.07.1

## Bug Fixes
- Fixed an issue where the app could crash if some models did not return valid results (#44).
  The update now handles NaN values in model outputs gracefully. If modeling results are missing or 
  invalid, they are excluded from the output summaries or replaced with a clear error message, 
  preventing unexpected crashes.