### PR TITLE
BMSCS 25.09.1: add tryCatch to renderPrint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BMSCS
 Title: Interface for Bayesian Model Selection under Constraints
-Version: 25.09.0
+Version: 25.09.1
 Authors@R: c(
     person("Marcus", "Groß", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BMSCS 25.09.1
+
+## Bug Fixes
+- Made `renderPrint()` more robust to gracefully handle `NaN` values, preventing crash scenarios. (#44)
+
 # BMSCS 25.09.0
 
 ## New Features

--- a/R/02-modelDW.R
+++ b/R/02-modelDW.R
@@ -73,7 +73,8 @@ modelDW <- function(input, output, session, model, data, modelAVG) {
   output$DWsummary <- renderPrint({
     req(model())
 
-    printFun()()
+    printFun()() |>
+      shinyTryCatch(errorTitle = "Printing Durbin-Watson test failed")
   })
 
   textExportServer("exportText", outFun = printFun, filename = "summary")

--- a/R/02-modelDiagnostics.R
+++ b/R/02-modelDiagnostics.R
@@ -53,7 +53,8 @@ modelDiagnostics <- function(input, output, session, model, nChains) {
   
   output$diagnostics <- renderPrint({
     req(model())
-    printFun()()
+    printFun()() |>
+      shinyTryCatch(errorTitle = "Printing model diagnostics failed")
   })
   
   textExportServer("exportText", outFun = printFun, filename = "diagnostics")

--- a/R/02-modelParameters.R
+++ b/R/02-modelParameters.R
@@ -64,12 +64,12 @@ modelParameters <- function(input, output, session, model, modelAVG) {
       group_by(.data$key) %>%
       summarise(
         # sd = sd(estimate),
-        med = median(.data$value),
-        meanEst = mean(.data$value),
-        q68 = quantile(.data$value, 0.68),
-        q95 = quantile(.data$value, 1 - ((1 - 0.95) / 2)),
-        q32 = quantile(.data$value, 1 - 0.68),
-        q05 = quantile(.data$value, (1 - 0.95) / 2)
+        med = median(.data$value, na.rm = TRUE),
+        meanEst = mean(.data$value, na.rm = TRUE),
+        q68 = quantile(.data$value, 0.68,  na.rm = TRUE, names = FALSE),
+        q95 = quantile(.data$value, 1 - ((1 - 0.95) / 2),  na.rm = TRUE, names = FALSE),
+        q32 = quantile(.data$value, 1 - 0.68,  na.rm = TRUE, names = FALSE),
+        q05 = quantile(.data$value, (1 - 0.95) / 2,  na.rm = TRUE, names = FALSE)
       ) %>%
       ungroup()
     p <- ggplot(dataSummary, aes_(x = ~ key)) +

--- a/R/02-modelSummary.R
+++ b/R/02-modelSummary.R
@@ -50,7 +50,8 @@ modelSummary <- function(input, output, session, model, modelAVG) {
 
     output$summary <- renderPrint({
         req(model())
-        printFun()()
+        printFun()() |>
+          shinyTryCatch(errorTitle = "Printing model summary failed")
     })
 
     textExportServer("exportText", outFun = printFun, filename = "summary")

--- a/R/02-modelVariables.R
+++ b/R/02-modelVariables.R
@@ -223,13 +223,15 @@ modelVariables <- function(input, output, session, model, data, modelAVG) {
     })
   
   output$correlations <- renderPrint({
-    if(input$modelData == "model"){
+    if (input$modelData == "model") {
       req(model())
-      correlationMatrix()()
-    } else{
+      correlationMatrix()() |> 
+        shinyTryCatch(errorTitle = "Printing correlation matrix failed")
+    } else {
       req(data())
       req(!is.null(input$variableSelection))
-      correlationMatrix()()
+      correlationMatrix()() |> 
+        shinyTryCatch(errorTitle = "Printing correlation matrix failed")
     }
   })
   


### PR DESCRIPTION
# BMSCS 25.09.1

## Bug Fixes
- Made `renderPrint()` more robust to gracefully handle `NaN` values, preventing crash scenarios. (#44)